### PR TITLE
when value is None, advancedsearchfilter fail with error "NoneType ob…

### DIFF
--- a/advancedsearchfilter/templatetags/advancedsearchfilter.py
+++ b/advancedsearchfilter/templatetags/advancedsearchfilter.py
@@ -83,6 +83,10 @@ def advanced_search(context, searchform):
                     value = ""
 
             key = "%s%s" % (field, suffix)
+
+            if value is None:
+                continue
+
             if value.strip() == "":
                 if key in querystr:
                     del querystr[key]


### PR DESCRIPTION
…ject has no attribute strip". Solved.
